### PR TITLE
Update the UUID columns in quick export menu

### DIFF
--- a/src/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
+++ b/src/Resources/public/js/datagrid/quickexport/component/QuickExportConfigurator.tsx
@@ -116,6 +116,19 @@ const QuickExportConfigurator = ({
                 </Option>
               </Select>
             )}
+            {showWithMediaSelect && (
+              <Select name="with_uuid">
+                <Option
+                  value="false"
+                  title={translate('pim_datagrid.mass_action.quick_export.configurator.without_uuid')}
+                >
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.without_uuid')}
+                </Option>
+                <Option value="true" title={translate('pim_datagrid.mass_action.quick_export.configurator.with_uuid')}>
+                  {translate('pim_datagrid.mass_action.quick_export.configurator.with_uuid')}
+                </Option>
+              </Select>
+            )}
           </Form>
         </Modal>
       )}


### PR DESCRIPTION
The uuid columns are not visible after installing the module due to override of this file. Updated the uuid select columns.