### PR TITLE
Support Akeneo 2026.x alongside 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name": "navneetbhardwaj/akeneo-quickexport-configurator",
   "type": "symfony-bundle",
-  "description": "quick export configurator for Akeneo 7",
-  "version": "1.1.6",
+  "description": "quick export configurator for Akeneo 7 and 2026.x",
+  "version": "1.1.7",
   "license": "OSL-3.0",
   "authors": [
     {
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "akeneo/pim-community-dev": "^7.0.0"
+    "akeneo/pim-community-dev": "^7.0.0 || ^2026.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9",


### PR DESCRIPTION
## Summary
- Extend `akeneo/pim-community-dev` constraint to `^7.0.0 || ^2026.0` so the bundle installs on current Akeneo releases.
- Bump version to `1.1.7`.

## Why
Users on Akeneo `v2026.x` hit a Composer conflict: the published `^1.1` resolves to `1.1.2` which requires `5.* || 6.*`, and even `1.1.6` is pinned to `^7.0.0`. No published version satisfies `2026.x`.

The bundle's PHP source uses zero Akeneo-namespaced classes (only Symfony DI + HttpFoundation), so the constraint bump is safe at install level.

## Post-merge
- Tag `v1.1.7` on the merged commit and push the tag.
- Trigger a manual Packagist update at https://packagist.org/packages/navneetbhardwaj/akeneo-quickexport-configurator — the GitHub webhook appears to be out of sync (Packagist still shows `1.1.2` as latest for `^1.1`).

## Test plan
- [ ] `composer require navneetbhardwaj/akeneo-quickexport-configurator:^1.1` resolves on an Akeneo 2026.x project
- [ ] `composer require navneetbhardwaj/akeneo-quickexport-configurator:^1.1` still resolves on an Akeneo 7.x project
- [ ] Quick export configurator UI loads in admin